### PR TITLE
Make axios instance available on the vue instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "scripts": {
     "dev": "node build/dev-server.js",
     "start": "npm run dev",
-    "lint": "eslint --ext .js,.vue src",
+    "lint": "eslint --ext .js,.vue src test",
     "unit": "jest test/unit --setupTestFrameworkScriptFile='<rootDir>/test/unit/setup.js'",
     "unit-dev": "jest test/unit --watch  --setupTestFrameworkScriptFile='<rootDir>/test/unit/setup.js'",
     "e2e": "node test/e2e/runner.js",
-    "test": "yarn unit && yarn e2e",
+    "test": "yarn lint && yarn unit && yarn e2e",
     "build": "node build/build.js"
   },
   "dependencies": {

--- a/src/traverser/install.js
+++ b/src/traverser/install.js
@@ -1,10 +1,13 @@
 import View from '@/traverser/view';
 import TraverserLink from '@/traverser/traverser-link';
 import { updateComponent } from '@/traverser/traverser';
+import axios from 'axios';
 
 const plugin = {
   install(Vue) {
     const traverserComponent = Vue.component('traverser-component', { template: '<p>traverser component...</p>' });
+
+    Vue.http = axios;
 
     Vue.mixin({
       beforeCreate() {
@@ -31,6 +34,8 @@ const plugin = {
     Object.defineProperty(Vue.prototype, '$context', {
       get() { return this._context; },
     });
+
+    Vue.prototype.http = axios;
 
     Vue.component(View.name, View);
     Vue.component(TraverserLink.name, TraverserLink);

--- a/test/unit/tests/axios.test.js
+++ b/test/unit/tests/axios.test.js
@@ -1,0 +1,63 @@
+import Traverser from '@/traverser/install';
+import Vue from 'vue';
+import Router from 'vue-router';
+import moxios from 'moxios';
+
+const { API_ROOT, PLONE_ROOT } = process.env;
+const options = { ploneRoot: PLONE_ROOT, apiRoot: API_ROOT };
+
+describe('axios instance', () => {
+  beforeEach(() => moxios.install());
+  afterEach(() => moxios.uninstall());
+
+  Vue.use(Router);
+  Vue.use(Traverser);
+
+  test('axios instance should be accessible on the vue instance under http', () => {
+    assert.isDefined(Vue.http);
+  });
+
+  test('axios instance should be accessible on vue components under http', () => {
+    const vm = new Vue();
+    assert.isDefined(vm.http);
+  });
+
+  test('matches given view when navigating', (done) => {
+    moxios.stubRequest('http://localhost:9000/plone/folder', {
+      status: 200,
+      response: {
+        '@type': 'Folder',
+        title: 'Title',
+        text: 'text',
+      },
+    });
+
+    const traverser = {
+      views: [{ view: 'view', type: 'Folder', component: { name: 'FolderViewComponent' } }],
+      options,
+    };
+
+    const router = new Router();
+
+    const vm = new Vue({
+      router,
+      traverser,
+      watch: {
+        $route: () => {
+          const request = moxios.requests.mostRecent();
+          assert.equal(request.config.headers.Authorization, 'secrettoken');
+          assert.equal(request.config.headers.RequestedWith, 'custom-header');
+          done();
+        },
+      },
+    });
+
+    vm.http.defaults.headers.common.Authorization = 'secrettoken';
+    vm.http.interceptors.request.use((request) => {
+      request.headers.RequestedWith = 'custom-header';
+      return request;
+    });
+
+    router.push('/folder');
+  });
+});

--- a/test/unit/tests/normalizer.test.js
+++ b/test/unit/tests/normalizer.test.js
@@ -1,5 +1,4 @@
-import normalize from '@/traverser/normalizer';
-import { createLink } from '@/traverser/normalizer';
+import normalize, { createLink } from '@/traverser/normalizer';
 
 const { API_ROOT, PLONE_ROOT } = process.env;
 

--- a/test/unit/tests/traverser.test.js
+++ b/test/unit/tests/traverser.test.js
@@ -76,7 +76,7 @@ describe('traverser', () => {
     Vue.use(Traverser);
 
     const traverser = {
-      views: [ { view: 'view', type: 'Folder', component: { name: 'FolderViewComponent' } } ],
+      views: [{ view: 'view', type: 'Folder', component: { name: 'FolderViewComponent' } }],
       options: {
         ploneRoot: PLONE_ROOT,
         apiRoot: API_ROOT,


### PR DESCRIPTION
This allows the user of the library to define options and interceptors for the http client. This can be used for setting Authorization Headers for example.