### PR TITLE
Implement default view.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ export default {
 </script>
 ```
 
+## Component lookup
+
+The component lookup is configured by passing a `views` list to the vue instance.
+The default view is defined as `@view`.
+
+So in the following example a request for `/folder` will resolve the `FolderViewComponent` and a request for `/folder/@edit` will resolve to `FolderEditComponent`.
+``` javascript
+const views = [
+  { type: 'Folder', component: { name: 'FolderViewComponent' } },
+  { view: 'edit', type: 'Folder', component: { name: 'FolderEditComponent' } },
+];
+```
+
+It is not possible to define the same view for the same type. So the following configuration will throw an error when trying to resolve `/folder/@edit`.
+``` javascript
+const views = [
+  { view: 'edit', type: 'Folder', component: { name: 'FolderViewComponent' } },
+  { view: 'edit', type: 'Folder', component: { name: 'FolderEditComponent' } },
+];
+```
+
+Also multple default views is not working. So the following configuration will also throw an error when trying to resolve `/folder`.
+``` javascript
+const views = [
+  { type: 'Folder', component: { name: 'FolderViewComponent' } },
+  { type: 'Folder', component: { name: 'FolderEditComponent' } },
+];
+```
+
 See `/src` for a full working example.
 
 ## Developing

--- a/src/traverser/traverser.js
+++ b/src/traverser/traverser.js
@@ -6,11 +6,31 @@ import executeHook from '@/traverser/traverseHook';
 export function lookup({ views, path, options }) {
   return resolve(path, options).then(({ res, view }) => {
     const type = res['@type'];
-    const componentLookup = views.find(v => v.type === type && v.view === view);
-    if (!componentLookup) {
+    const componentsByType = views.filter(v => v.type === type);
+
+    if (!componentsByType.length) {
       throw new Error(`Component for type "${type}" could not be found`);
     }
-    return { component: componentLookup.component, context: res };
+
+    const componentsByView = componentsByType.filter(v => v.view === view);
+
+    if (componentsByView.length > 1) {
+      throw new Error(`Multiple views named "${view}" defined for component with type "${type}"`);
+    }
+
+    const componentLookup = componentsByView.find(v => v.view === view);
+
+    if (componentLookup) {
+      return { component: componentLookup.component, context: res };
+    }
+
+    const defaultViews = views.filter(v => !v.view);
+
+    if (defaultViews.length > 1) {
+      throw new Error(`Multiple default views defined for component with type "${type}"`);
+    }
+
+    return { component: defaultViews[0].component, context: res };
   });
 }
 

--- a/test/unit/tests/traverser.test.js
+++ b/test/unit/tests/traverser.test.js
@@ -47,6 +47,66 @@ describe('traverser', () => {
     });
   });
 
+  test('default view is @view', (done) => {
+    const views = [
+      { type: 'Folder', component: { name: 'FolderViewComponent' } },
+      { view: 'edit', type: 'Folder', component: { name: 'FolderEditComponent' } },
+    ];
+
+    const paths = [
+      '/folder',
+      '/folder/@edit',
+    ];
+
+    Promise.all(paths.map(path => lookup({ views, path, options }))).then((cs) => {
+      assert.deepEqual(
+        cs.map(c => c.component.name),
+        [
+          'FolderViewComponent',
+          'FolderEditComponent',
+        ],
+      );
+      done();
+    });
+  });
+
+  test('multiple views defined for same type throws Error', (done) => {
+    const views = [
+      { view: 'edit', type: 'Folder', component: { name: 'FolderViewComponent' } },
+      { view: 'edit', type: 'Folder', component: { name: 'FolderEditComponent' } },
+    ];
+
+    const path = '/folder/@edit';
+
+    lookup({ views, path, options }).catch((e) => {
+      assert.equal(e.message, 'Multiple views named "edit" defined for component with type "Folder"');
+      done();
+    });
+  });
+
+  test('multiple default views defined for same type throws Error', (done) => {
+    const views = [
+      { type: 'Folder', component: { name: 'FolderViewComponent' } },
+      { type: 'Folder', component: { name: 'FolderEditComponent' } },
+    ];
+
+    const path = '/folder';
+
+    lookup({ views, path, options }).catch((e) => {
+      assert.equal(e.message, 'Multiple default views defined for component with type "Folder"');
+      done();
+    });
+  });
+
+  test('throws error when no component as been found', (done) => {
+    const views = [];
+    const path = '/folder';
+    lookup({ views, path, options }).catch((e) => {
+      assert.equal(e.message, 'Component for type "Folder" could not be found');
+      done();
+    });
+  });
+
   test('matches given view when navigating', (done) => {
     Vue.use(Router);
     Vue.use(Traverser);


### PR DESCRIPTION
The default view is always `@view`.
The lookup throws an error when no component has been found or
when the same view is defined multiple times for the same type.